### PR TITLE
Add bandit code checker

### DIFF
--- a/roles/atat.builder/defaults/main.yml
+++ b/roles/atat.builder/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 # Default root directory for apps
 app_root_dir: /opt/atat
+
+python_packages:
+- bandit
+- pipenv

--- a/roles/atat.builder/tasks/main.yml
+++ b/roles/atat.builder/tasks/main.yml
@@ -16,7 +16,7 @@
     group: root
 
 # Install the sass gem
-- name: Install SASS
+- name: Install SASS gem
   gem:
     name: sass
     state: present

--- a/roles/atat.builder/tasks/main.yml
+++ b/roles/atat.builder/tasks/main.yml
@@ -28,6 +28,11 @@
     name: pip
     state: latest
 
+# Display Python packages to be installed
+- name: Show selected Python packages
+  debug:
+    msg: "Packages: {{ python_packages | join(', ') }}"
+
 # Install Python packages
 - name: Install Python packages
   pip:

--- a/roles/atat.builder/tasks/main.yml
+++ b/roles/atat.builder/tasks/main.yml
@@ -28,9 +28,9 @@
     name: pip
     state: latest
 
-# Install PipEnv
-- name: Install PipEnv
+# Install Python packages
+- name: Install Python packages
   pip:
     executable: pip3.6
-    name: pipenv
+    name: "{{ python_packages }}"
     state: latest

--- a/roles/atat.builder/tasks/setup-Alpine.yml
+++ b/roles/atat.builder/tasks/setup-Alpine.yml
@@ -1,9 +1,16 @@
 ---
+# Update apk cache and existing system packages
 - name: "Alpine Setup: Ensure image is up-to-date"
   apk:
     update_cache: yes
     upgrade: yes
 
+# Display system packages to be installed
+- name: Show selected system packages
+  debug:
+    msg: "Packages: {{ builder_packages | join(', ') }}"
+
+# Install system packages
 - name: "Alpine Setup: Install builder packages"
   apk:
     name: "{{ builder_packages }}"

--- a/roles/atat.builder/tasks/setup-Alpine.yml
+++ b/roles/atat.builder/tasks/setup-Alpine.yml
@@ -1,10 +1,10 @@
 ---
-- name: Ensure image is up-to-date
+- name: Alpine Setup: Ensure image is up-to-date
   apk:
     update_cache: yes
     upgrade: yes
 
-- name: Install builder packages
+- name: Alpine Setup: Install builder packages
   apk:
     name: "{{ builder_packages }}"
     state: latest

--- a/roles/atat.builder/tasks/setup-Alpine.yml
+++ b/roles/atat.builder/tasks/setup-Alpine.yml
@@ -1,10 +1,10 @@
 ---
-- name: Alpine Setup: Ensure image is up-to-date
+- name: "Alpine Setup: Ensure image is up-to-date"
   apk:
     update_cache: yes
     upgrade: yes
 
-- name: Alpine Setup: Install builder packages
+- name: "Alpine Setup: Install builder packages"
   apk:
     name: "{{ builder_packages }}"
     state: latest

--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -2,12 +2,12 @@
 builder_packages:
 - bash
 - build-base
-- ruby
-- ruby-dev
-- nodejs
-- nodejs-npm
-- libsass
-- libsass-dev
 - libffi
 - libffi-dev
+- libsass
+- libsass-dev
+- nodejs
+- nodejs-npm
 - postgresql-dev
+- ruby
+- ruby-dev


### PR DESCRIPTION
Mostly this PR just adds Bandit to the base image.
Bandit does security focused static code analysis for Python apps.

- Add bandit (via pip)
- Rearrange Python package installs in to a list
- Add some comments and output text to make the ansible-container run more informative