### PR TITLE
Add psql client package for createdb and dropdb commands

### DIFF
--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -8,6 +8,7 @@ builder_packages:
 - libsass-dev
 - nodejs
 - nodejs-npm
+- postgresql-client
 - postgresql-dev
 - ruby
 - ruby-dev


### PR DESCRIPTION
This PR adds the postgres-client package so that the build image has access to commands like createdb and dropdb (used during application setup).