### PR TITLE
Switch from npm to yarn

### DIFF
--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -7,8 +7,8 @@ builder_packages:
 - libsass
 - libsass-dev
 - nodejs
-- nodejs-npm
 - postgresql-client
 - postgresql-dev
 - ruby
 - ruby-dev
+- yarn


### PR DESCRIPTION
Swaps out npm for yarn, which is now used by the build scripts to install node modules.