### PR TITLE
Add util-linux to get lscpu for parcel

### DIFF
--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -6,6 +6,7 @@ builder_packages:
 - libffi-dev
 - libsass
 - libsass-dev
+- util-linux
 - nodejs
 - postgresql-client
 - postgresql-dev


### PR DESCRIPTION
This PR adds one additional package to the app building base image: util-linux
This packages contains a number of different linux utilities, including lscpu (which parcel uses to decide how many parallel processes it can run).