### PR TITLE
Use general alpine

### DIFF
--- a/container.yml
+++ b/container.yml
@@ -7,7 +7,7 @@ settings:
 
 services:
   builder:
-    from: python:3.6.5-alpine
+    from: alpine:3.8
     roles:
       - atat.builder
 registries: {}

--- a/roles/atat.builder/tasks/main.yml
+++ b/roles/atat.builder/tasks/main.yml
@@ -7,20 +7,6 @@
 - name: Run OS-specific setup tasks
   include_tasks: "setup-{{ ansible_os_family }}.yml"
 
-# Add a gemrc file
-- name: Add gemrc
-  copy:
-    src: gemrc
-    dest: /root/.gemrc
-    owner: root
-    group: root
-
-# Install the sass gem
-- name: Install SASS gem
-  gem:
-    name: sass
-    state: present
-
 # Ensure Pip is up-to-date
 - name: Update Pip
   pip:

--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -11,7 +11,5 @@ builder_packages:
 - postgresql-dev
 - python3
 - python3-dev
-- ruby
-- ruby-dev
 - util-linux
 - yarn

--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -6,10 +6,12 @@ builder_packages:
 - libffi-dev
 - libsass
 - libsass-dev
-- util-linux
 - nodejs
 - postgresql-client
 - postgresql-dev
+- python3
+- python3-dev
 - ruby
 - ruby-dev
+- util-linux
 - yarn


### PR DESCRIPTION
This PR converts the app building case image to the generic alpine:3.8 base due to downstream package dependency problems.
It also removes the Ruby packages since they are no longer needed.