### PR TITLE
Add python symlink for greater compatibility

### DIFF
--- a/roles/atat.builder/tasks/main.yml
+++ b/roles/atat.builder/tasks/main.yml
@@ -25,3 +25,9 @@
     executable: pip3.6
     name: "{{ python_packages }}"
     state: latest
+
+- name: Add Python binary symlink
+  file:
+    src: /usr/bin/python3
+    dest: /usr/bin/python
+    state: link


### PR DESCRIPTION
Point /usr/bin/python to /usr/bin/python3, for anything looking for python that does not check for the python3 binary explicitly.