### PR TITLE
Circleci compat

### DIFF
--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -2,14 +2,20 @@
 builder_packages:
 - bash
 - build-base
+- ca-certificates-20171114-r3
+- git
+- gzip
 - libffi
 - libffi-dev
 - libsass
 - libsass-dev
 - nodejs
+- openssh-client
 - postgresql-client
 - postgresql-dev
 - python3
 - python3-dev
+- sudo
+- tar
 - util-linux
 - yarn

--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -2,7 +2,7 @@
 builder_packages:
 - bash
 - build-base
-- ca-certificates-20171114-r3
+- ca-certificates
 - git
 - gzip
 - libffi
@@ -15,6 +15,7 @@ builder_packages:
 - postgresql-dev
 - python3
 - python3-dev
+- rsync
 - sudo
 - tar
 - util-linux


### PR DESCRIPTION
Adds some additional system packages to the image, allowing apps to built directly in the image with CircleCI