### PR TITLE
Add kubectl

### DIFF
--- a/roles/atat.builder/tasks/main.yml
+++ b/roles/atat.builder/tasks/main.yml
@@ -31,3 +31,16 @@
     src: /usr/bin/python3
     dest: /usr/bin/python
     state: link
+
+- name: Register latest kubectl version
+  uri:
+    url: https://storage.googleapis.com/kubernetes-release/release/stable.txt
+    timeout: 10
+    return_content: yes
+  register: kubectl_version_response
+
+- name: Install kubectl
+  get_url:
+    url: "https://storage.googleapis.com/kubernetes-release/release/{{ kubectl_version_response.content | trim }}/bin/linux/amd64/kubectl"
+    dest: /usr/bin
+    mode: 0755

--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -2,6 +2,7 @@
 builder_packages:
 - bash
 - build-base
+- curl
 - ca-certificates
 - docker
 - git
@@ -12,6 +13,7 @@ builder_packages:
 - libsass-dev
 - nodejs
 - openssh-client
+- openssl
 - postgresql-client
 - postgresql-dev
 - python3

--- a/roles/atat.builder/vars/Alpine.yml
+++ b/roles/atat.builder/vars/Alpine.yml
@@ -3,6 +3,7 @@ builder_packages:
 - bash
 - build-base
 - ca-certificates
+- docker
 - git
 - gzip
 - libffi


### PR DESCRIPTION
This PR adds the kubectl binary to the app builder image, so it can later be used for updating the Kubernetes cluster with a new image (used during Deploy steps).